### PR TITLE
fix: implement SSE streaming for chat completions (fixes #4)

### DIFF
--- a/ragorchestrator/app.py
+++ b/ragorchestrator/app.py
@@ -11,7 +11,7 @@ import time
 import uuid
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from prometheus_client import Counter, Histogram, generate_latest
 
 from ragorchestrator import __version__
@@ -111,9 +111,24 @@ async def chat_completions(request: Request):
         else:
             lc_messages.append(HumanMessage(content=content))
 
+    stream = body.get("stream", False)
+    model_name = body.get("model", "ragorchestrator")
+
+    if stream:
+        if complexity == Complexity.SIMPLE:
+            return StreamingResponse(
+                _stream_simple_path(user_query, model_name, start),
+                media_type="text/event-stream",
+            )
+        else:
+            return StreamingResponse(
+                _stream_agentic_path(lc_messages, model_name, start),
+                media_type="text/event-stream",
+            )
+
     try:
         if complexity == Complexity.SIMPLE:
-            result = await _simple_path(user_query, body.get("model", "ragorchestrator"))
+            result = await _simple_path(user_query, model_name)
         else:
             result = await _agentic_path(lc_messages)
 
@@ -140,7 +155,7 @@ async def chat_completions(request: Request):
         response = {
             "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
             "object": "chat.completion",
-            "model": body.get("model", "ragorchestrator"),
+            "model": model_name,
             "choices": [
                 {
                     "index": 0,
@@ -161,6 +176,119 @@ async def chat_completions(request: Request):
         queries_total.labels(status="error").inc()
         log.exception("Query processing failed")
         return JSONResponse({"error": str(e)}, status_code=500)
+
+
+def _sse_chunk(chunk_id: str, model: str, content: str, finish_reason: str | None = None) -> str:
+    """Format a single SSE chunk in OpenAI streaming format."""
+    data = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": content} if content else {},
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    return f"data: {json.dumps(data)}\n\n"
+
+
+async def _stream_simple_path(query: str, model: str, start: float):
+    """Stream SSE events by proxying ragpipe's streaming response."""
+    import httpx
+
+    ragpipe_url = os.environ.get("RAGPIPE_URL", "http://localhost:8090")
+    ragpipe_token = os.environ.get("RAGPIPE_ADMIN_TOKEN", "")
+
+    headers = {"Content-Type": "application/json"}
+    if ragpipe_token:
+        headers["Authorization"] = f"Bearer {ragpipe_token}"
+
+    payload = {
+        "model": "default",
+        "messages": [{"role": "user", "content": query}],
+        "temperature": 0,
+        "stream": True,
+    }
+
+    chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+    try:
+        async with httpx.AsyncClient(timeout=120) as client:
+            async with client.stream(
+                "POST",
+                f"{ragpipe_url}/v1/chat/completions",
+                json=payload,
+                headers=headers,
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    payload_str = line[6:]
+                    if payload_str.strip() == "[DONE]":
+                        break
+                    try:
+                        data = json.loads(payload_str)
+                        delta = data.get("choices", [{}])[0].get("delta", {})
+                        content = delta.get("content", "")
+                        if content:
+                            yield _sse_chunk(chunk_id, model, content)
+                    except json.JSONDecodeError:
+                        continue
+
+        elapsed = time.monotonic() - start
+        query_latency.observe(elapsed)
+        queries_total.labels(status="success").inc()
+    except Exception as e:
+        log.exception("Streaming simple path failed")
+        elapsed = time.monotonic() - start
+        query_latency.observe(elapsed)
+        queries_total.labels(status="error").inc()
+        yield _sse_chunk(chunk_id, model, f"\n\n[Error: {e}]")
+
+    yield _sse_chunk(chunk_id, model, "", finish_reason="stop")
+    yield "data: [DONE]\n\n"
+
+
+async def _stream_agentic_path(lc_messages: list, model: str, start: float):
+    """Run agentic graph, then stream the final content as SSE chunks."""
+    chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+    try:
+        graph = get_graph()
+        result = await graph.ainvoke({"messages": lc_messages})
+
+        # Count tool calls
+        for msg in result["messages"]:
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_calls_total.labels(tool=tc.get("name", "unknown")).inc()
+
+        final_msg = result["messages"][-1]
+        content = final_msg.content if hasattr(final_msg, "content") else str(final_msg)
+
+        # Emit content in word-sized chunks for a natural streaming feel
+        words = content.split(" ")
+        for i, word in enumerate(words):
+            token = word if i == 0 else f" {word}"
+            yield _sse_chunk(chunk_id, model, token)
+
+        elapsed = time.monotonic() - start
+        query_latency.observe(elapsed)
+        queries_total.labels(status="success").inc()
+        log.info("Streaming agentic path completed")
+    except Exception as e:
+        log.exception("Streaming agentic path failed")
+        elapsed = time.monotonic() - start
+        query_latency.observe(elapsed)
+        queries_total.labels(status="error").inc()
+        yield _sse_chunk(chunk_id, model, f"Error: {e}")
+
+    yield _sse_chunk(chunk_id, model, "", finish_reason="stop")
+    yield "data: [DONE]\n\n"
 
 
 async def _simple_path(query: str, model: str) -> dict:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,12 @@
 """Tests for the FastAPI app."""
 
+import json
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
-from ragorchestrator.app import app
+from ragorchestrator.app import _sse_chunk, app
 
 
 @pytest.fixture
@@ -31,3 +34,85 @@ def test_chat_completions_no_messages(client):
     """Empty messages should return 400."""
     resp = client.post("/v1/chat/completions", json={"messages": []})
     assert resp.status_code == 400
+
+
+def test_sse_chunk_format():
+    """SSE chunk helper should produce valid OpenAI streaming format."""
+    chunk = _sse_chunk("chatcmpl-abc", "test-model", "hello")
+    assert chunk.startswith("data: ")
+    assert chunk.endswith("\n\n")
+    data = json.loads(chunk[6:])
+    assert data["object"] == "chat.completion.chunk"
+    assert data["choices"][0]["delta"]["content"] == "hello"
+    assert data["choices"][0]["finish_reason"] is None
+
+
+def test_sse_chunk_finish():
+    """SSE chunk with finish_reason should set it and have empty delta."""
+    chunk = _sse_chunk("chatcmpl-abc", "test-model", "", finish_reason="stop")
+    data = json.loads(chunk[6:])
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert data["choices"][0]["delta"] == {}
+
+
+def test_stream_simple_returns_sse(client):
+    """Streaming simple query should return text/event-stream."""
+    ragpipe_lines = [
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+        'data: {"choices":[{"delta":{"content":" world"}}]}',
+        "data: [DONE]",
+    ]
+
+    async def mock_aiter_lines():
+        for line in ragpipe_lines:
+            yield line
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = lambda: None
+    mock_response.aiter_lines = mock_aiter_lines
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = AsyncMock()
+    mock_client.stream = lambda *args, **kwargs: mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "who is adam"}],
+                "stream": True,
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    body = resp.text
+    assert "data: " in body
+    assert "data: [DONE]" in body
+
+
+def test_stream_false_returns_json(client):
+    """Non-streaming request should still return JSON."""
+    from langchain_core.messages import AIMessage
+
+    mock_result = {
+        "messages": [AIMessage(content="test answer")],
+        "rag_metadata": {"grounding": "corpus"},
+    }
+
+    with patch("ragorchestrator.app._simple_path", new_callable=AsyncMock, return_value=mock_result):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "who is adam"}],
+                "stream": False,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "choices" in data
+    assert data["choices"][0]["message"]["content"] == "test answer"


### PR DESCRIPTION
## Summary
- **Simple path** (SIMPLE queries): true SSE streaming proxy from ragpipe — client receives tokens as ragpipe generates them
- **Agentic path** (COMPLEX queries): runs graph to completion, then emits final content as word-level SSE chunks
- Both paths emit standard OpenAI SSE format (`data: {...}\n\n` with `data: [DONE]\n\n`)

Closes #4

## What was broken
`stream=true` in the request body was silently ignored — clients always received non-streaming JSON responses. Open WebUI and other streaming clients would hang or show no output.

## Test plan
- [x] `test_sse_chunk_format` — validates SSE chunk structure
- [x] `test_sse_chunk_finish` — validates finish_reason handling
- [x] `test_stream_simple_returns_sse` — mock ragpipe SSE proxy
- [x] `test_stream_false_returns_json` — non-streaming path unchanged
- [x] Full suite: 50/50 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)