### PR TITLE
chore(ci): add dependabot config (fixes #11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Closes #11

## Problem
ragorchestrator was missing dependabot.yml for automated dependency updates, unlike other repos in the stack (ragstuffer, ragwatch, ragdeck).

## Solution
Added .github/dependabot.yml with weekly updates for:
- pip (Python dependencies, minor+patch grouped)
- docker (Containerfile base images)
- github-actions (CI action versions)

Matches the pattern used across ragstuffer, ragwatch, and ragdeck.

## Testing
Config-only change — no tests needed. Dependabot will start creating PRs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency update checks across Python, Docker, and GitHub Actions ecosystems, with grouped minor and patch updates for Python.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->