### PR TITLE
fix(ragorchestrator): add missing env vars and known limitations to README (fixes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ curl http://localhost:8095/v1/chat/completions \
 | `RAGPIPE_URL` | `http://localhost:8090` | ragpipe endpoint |
 | `RAGPIPE_ADMIN_TOKEN` | | Bearer token for ragpipe |
 | `RAGORCHESTRATOR_PORT` | `8095` | Listen port |
+| `TAVILY_API_KEY` | | Tavily API key for web search (optional) |
+| `DISABLE_WEB_SEARCH` | | Set to `true` to force-disable web search (sovereign mode) |
+
+## Known limitations
+
+- **Streaming not supported**: The `/v1/chat/completions` endpoint always returns a complete response. Streaming responses are not yet implemented.
+- **Web search requires API key**: The `TAVILY_API_KEY` environment variable must be set to enable web search functionality. Without it, the web search tool is disabled.
 
 ## Health and metrics
 


### PR DESCRIPTION
Closes #25

## Change
- Added missing environment variables: TAVILY_API_KEY, DISABLE_WEB_SEARCH
- Added known limitations section documenting streaming not supported and web search requires API key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for environment variable configuration options: `TAVILY_API_KEY` for enabling web search and `DISABLE_WEB_SEARCH` for disabling it.
  * Documented known limitations including streaming support and web search functionality dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->