### PR TITLE
Expose complexity classification in API response (fixes #21)

### DIFF
--- a/ragorchestrator/app.py
+++ b/ragorchestrator/app.py
@@ -117,12 +117,12 @@ async def chat_completions(request: Request):
     if stream:
         if complexity == Complexity.SIMPLE:
             return StreamingResponse(
-                _stream_simple_path(user_query, model_name, start),
+                _stream_simple_path(user_query, model_name, start, complexity.value),
                 media_type="text/event-stream",
             )
         else:
             return StreamingResponse(
-                _stream_agentic_path(lc_messages, model_name, start),
+                _stream_agentic_path(lc_messages, model_name, start, complexity.value),
                 media_type="text/event-stream",
             )
 
@@ -165,6 +165,8 @@ async def chat_completions(request: Request):
             ],
         }
 
+        response["complexity"] = complexity.value
+
         if rag_metadata:
             response["rag_metadata"] = rag_metadata
 
@@ -195,7 +197,7 @@ def _sse_chunk(chunk_id: str, model: str, content: str, finish_reason: str | Non
     return f"data: {json.dumps(data)}\n\n"
 
 
-async def _stream_simple_path(query: str, model: str, start: float):
+async def _stream_simple_path(query: str, model: str, start: float, complexity: str = "simple"):
     """Stream SSE events by proxying ragpipe's streaming response."""
     import httpx
 
@@ -250,10 +252,11 @@ async def _stream_simple_path(query: str, model: str, start: float):
         yield _sse_chunk(chunk_id, model, f"\n\n[Error: {e}]")
 
     yield _sse_chunk(chunk_id, model, "", finish_reason="stop")
+    yield f"data: {json.dumps({'complexity': complexity})}\n\n"
     yield "data: [DONE]\n\n"
 
 
-async def _stream_agentic_path(lc_messages: list, model: str, start: float):
+async def _stream_agentic_path(lc_messages: list, model: str, start: float, complexity: str = "complex"):
     """Run agentic graph, then stream the final content as SSE chunks."""
     chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
@@ -288,6 +291,7 @@ async def _stream_agentic_path(lc_messages: list, model: str, start: float):
         yield _sse_chunk(chunk_id, model, f"Error: {e}")
 
     yield _sse_chunk(chunk_id, model, "", finish_reason="stop")
+    yield f"data: {json.dumps({'complexity': complexity})}\n\n"
     yield "data: [DONE]\n\n"
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -116,3 +116,52 @@ def test_stream_false_returns_json(client):
     data = resp.json()
     assert "choices" in data
     assert data["choices"][0]["message"]["content"] == "test answer"
+
+
+def test_complexity_field_in_response(client):
+    """Non-streaming response must include complexity field (fixes #21)."""
+    from langchain_core.messages import AIMessage
+
+    mock_result = {
+        "messages": [AIMessage(content="Paris is the capital of France.")],
+        "rag_metadata": {"grounding": "general"},
+    }
+
+    with patch("ragorchestrator.app._simple_path", new_callable=AsyncMock, return_value=mock_result):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "what is the capital of France"}],
+                "stream": False,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "complexity" in data, "Response missing complexity field"
+    assert data["complexity"] == "simple"
+
+
+def test_complexity_field_complex_query(client):
+    """Complex queries should show complexity=complex in response (fixes #21)."""
+    from langchain_core.messages import AIMessage
+
+    mock_result = {
+        "messages": [AIMessage(content="Comparing NATO and patent law...")],
+    }
+
+    with patch("ragorchestrator.app._agentic_path", new_callable=AsyncMock, return_value=mock_result):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {"role": "user", "content": "Compare and analyze NATO Article 5 with patent claims requirements"}
+                ],
+                "stream": False,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "complexity" in data
+    assert data["complexity"] == "complex"


### PR DESCRIPTION
Closes #21

## Problem
The adaptive classifier determines query complexity but only records it as a Prometheus metric. The classification is not included in the response body, making agentic behavior a black box to clients.

## Solution
Add `complexity` field to `/v1/chat/completions` response:
- Non-streaming: top-level field in JSON response (`"complexity": "simple"`)
- Streaming: emitted as SSE event before `[DONE]`

Values: `simple`, `complex`, `external`

## Testing
- 64 tests passing (2 new: `test_complexity_field_in_response`, `test_complexity_field_complex_query`)
- Ruff clean

## Verification
```bash
curl -s http://localhost:8095/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"default","messages":[{"role":"user","content":"hello"}]}' \
  | python3 -c "import sys,json; print(json.load(sys.stdin).get('complexity','MISSING'))"
```