### PR TITLE
feat(ragorchestrator): add PR and issue templates (fixes #38)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: Report something that's broken
+title: "fix: <what's broken>"
+labels: type: bug,priority: medium
+assignees: ''
+---
+
+## Problem
+Describe what is broken and expected behavior.
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Environment
+- OS:
+- Version:
+
+## Logs
+```
+
+```
+
+## Proposed Fix

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature
+about: Request new functionality
+title: "feat: <description>"
+labels: type: feature,priority: medium
+assignees: ''
+---
+
+## Context
+Why is this needed?
+
+## Requirements
+-
+-
+
+## Success Criteria
+-
+-
+
+## Related Issues

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -1,0 +1,22 @@
+---
+name: Infrastructure
+about: Infrastructure or deployment work
+title: "infra: <description>"
+labels: type: infrastructure,priority: medium
+assignees: ''
+---
+
+## Context
+What needs to be done?
+
+## Current State
+Describe current infrastructure.
+
+## Desired State
+What should change?
+
+## Plan
+-
+-
+
+## Dependencies

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,28 @@
+---
+name: Research Spike
+about: Investigate and evaluate options
+title: "research: <topic>"
+labels: type: feature,priority: low
+assignees: ''
+---
+
+## Question
+What are we researching?
+
+## Background
+Context and prior work.
+
+## Research Plan
+-
+-
+
+## Evaluation Criteria
+-
+-
+
+## Options to Evaluate
+1.
+2.
+
+## Expected Output
+Document findings and recommendation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Problem
+
+<!-- What was wrong or missing? Link to the issue: Closes #N -->
+
+## Solution
+
+<!-- What was changed and why? -->
+
+## Testing
+
+<!-- How was this tested? Include test counts before/after if applicable. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] Linting passes (`ruff check`)
+- [ ] Type checking passes (`mypy`)
+- [ ] No secrets committed
+- [ ] Commit messages reference the issue (`fixes #N` or `refs #N`)


### PR DESCRIPTION
Closes #38

Adds `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/` (bug, feature, infrastructure, research) to ragorchestrator, matching the rag-suite templates used as reference.

## Testing
- Templates verified present in .github/ directory