### PR TITLE
docs: add architecture SVG, docs/ directory, and expand README (fixes #37, fixes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,81 @@
 # ragorchestrator
 
-LangGraph supervisor agent for [ragpipe](https://github.com/aclater/ragpipe) — agentic RAG orchestration with tool selection, query decomposition, and adaptive complexity routing.
+LangGraph supervisor agent for [ragpipe](https://github.com/aclater/ragpipe) — agentic RAG orchestration with adaptive complexity routing, multi-pass retrieval, and Self-RAG reflection.
 
-## Architecture
+![Architecture](architecture.svg)
 
-```
-Client → ragorchestrator (:8095) → LangGraph supervisor
-                                        ↓
-                                  [ragpipe_retrieval]
-                                        ↓
-                                  ragpipe (:8090)
-                                        ↓
-                                  corpus answer + citations
-```
+## Features
 
-ragorchestrator exposes an OpenAI-compatible API at port 8095. It's a drop-in replacement for ragpipe for clients that want agentic behavior. The supervisor decides whether to call ragpipe for corpus-grounded answers or respond directly for general knowledge queries.
+- **Adaptive complexity routing** — deterministic keyword classifier routes SIMPLE queries to ragpipe directly (~2s) and COMPLEX queries through the full agentic loop (~30-120s). See [classifier docs](docs/classifier.md).
+- **Multi-pass retrieval** — complex queries are decomposed into sub-queries, retrieved in parallel from ragpipe, and deduplicated. See [multipass docs](docs/multipass.md).
+- **Self-RAG reflection** — after generation, the supervisor grades its own response for groundedness and usefulness, retrying up to 2 times. See [self-rag docs](docs/self-rag.md).
+- **ragpipe as a tool** — corpus retrieval with citations preserved end-to-end via LangGraph ToolNode.
+- **OpenAI-compatible API** — same `/v1/chat/completions` schema as ragpipe. Switch by changing the port.
+- **Sovereign deployment** — all LLM calls to local model, no external APIs. Optional Tavily web search.
+- **Prometheus metrics** — query latency, tool call counts, complexity distribution.
 
 ## Quick start
 
 ```bash
-# Prerequisites: ragpipe running on :8090, LLM on :8080
+# Prerequisites: ragpipe on :8090, LLM on :8080
 pip install '.[dev]'
 python -m ragorchestrator
 
-# Query
+# Simple query (fast path)
 curl http://localhost:8095/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"default","messages":[{"role":"user","content":"What is Adam Claters job title?"}]}'
+  -d '{"model":"default","messages":[{"role":"user","content":"Who is Adam Clater?"}]}'
+
+# Complex query (agentic path)
+curl http://localhost:8095/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"default","messages":[{"role":"user","content":"Compare NATO article 5 with patent claims requirements"}]}'
 ```
 
-## Key features
+## Documentation
 
-- **LangGraph supervisor**: Adaptive routing via tool-calling LLM
-- **ragpipe as a tool**: Corpus retrieval with citations preserved
-- **OpenAI-compatible API**: Same request/response schema as ragpipe
-- **Prometheus metrics**: Query latency, tool call counts, error rates
-- **Sovereign deployment**: All LLM calls to local model, no external APIs
+| Document | Description |
+|----------|-------------|
+| [Architecture](docs/architecture.md) | LangGraph supervisor design, state machine, request flow |
+| [Classifier](docs/classifier.md) | Adaptive complexity routing — SIMPLE/COMPLEX/EXTERNAL |
+| [Self-RAG](docs/self-rag.md) | Reflection grading, retry logic, short-circuit optimization |
+| [Multi-pass](docs/multipass.md) | Query decomposition, parallel retrieval, deduplication |
+| [API](docs/api.md) | Endpoints, request/response format, rag_metadata, streaming |
+| [Configuration](docs/configuration.md) | Environment variables, IPv4 requirement, sovereign mode |
 
 ## Environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MODEL_URL` | `http://localhost:8080` | LLM endpoint |
+| `MODEL_URL` | `http://127.0.0.1:8080` | LLM endpoint (must use IPv4) |
 | `MODEL_NAME` | `model.file` | Model name for LangChain |
 | `RAGPIPE_URL` | `http://localhost:8090` | ragpipe endpoint |
 | `RAGPIPE_ADMIN_TOKEN` | | Bearer token for ragpipe |
 | `RAGORCHESTRATOR_PORT` | `8095` | Listen port |
-| `TAVILY_API_KEY` | | Tavily API key for web search (optional) |
-| `DISABLE_WEB_SEARCH` | | Set to `true` to force-disable web search (sovereign mode) |
+| `TAVILY_API_KEY` | | Tavily API key (optional, tool disabled if unset) |
+| `DISABLE_WEB_SEARCH` | | Set to `true` for sovereign mode |
+
+See [configuration docs](docs/configuration.md) for deployment details.
 
 ## Known limitations
 
-- **Streaming not supported**: The `/v1/chat/completions` endpoint always returns a complete response. Streaming responses are not yet implemented.
-- **Web search requires API key**: The `TAVILY_API_KEY` environment variable must be set to enable web search functionality. Without it, the web search tool is disabled.
+- **Agentic path latency**: COMPLEX queries make 5+ sequential LLM calls (~30-120s with Qwen3-32B)
+- **Web search disabled by default**: Set `TAVILY_API_KEY` and unset `DISABLE_WEB_SEARCH` to enable
+- **IPv4 required**: `MODEL_URL` must use `127.0.0.1` not `localhost` on Fedora (IPv6 resolution issue)
 
 ## Health and metrics
 
 ```bash
-curl http://localhost:8095/health
-curl http://localhost:8095/metrics
+curl http://localhost:8095/health     # {"status": "ok", "version": "0.1.0"}
+curl http://localhost:8095/metrics    # Prometheus text format
+```
+
+## Tests
+
+```bash
+pip install '.[dev]'
+python -m pytest tests/ -v           # unit tests
+python -m pytest tests/ -v --live    # + live integration tests
 ```
 
 ## License

--- a/architecture.svg
+++ b/architecture.svg
@@ -1,0 +1,119 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">
+  <style>
+    .box { stroke-width: 2; rx: 8; ry: 8; }
+    .simple { fill: #1a7f37; stroke: #1a7f37; }
+    .complex { fill: #9a6700; stroke: #9a6700; }
+    .node { fill: #0969da; stroke: #0969da; }
+    .reflect { fill: #8250df; stroke: #8250df; }
+    .external { fill: #cf222e; stroke: #cf222e; }
+    .service { fill: #656d76; stroke: #656d76; }
+    .label { fill: #fff; font-weight: bold; text-anchor: middle; dominant-baseline: central; }
+    .edge { stroke: #656d76; stroke-width: 1.5; fill: none; marker-end: url(#arrow); }
+    .edge-simple { stroke: #1a7f37; stroke-width: 2; fill: none; marker-end: url(#arrow-simple); }
+    .edge-complex { stroke: #9a6700; stroke-width: 2; fill: none; marker-end: url(#arrow-complex); }
+    .edge-reflect { stroke: #8250df; stroke-width: 1.5; fill: none; stroke-dasharray: 6,3; marker-end: url(#arrow-reflect); }
+    .note { fill: #656d76; font-size: 10; font-style: italic; }
+    .title { fill: #1f2328; font-size: 18; font-weight: bold; }
+    @media (prefers-color-scheme: dark) {
+      .title { fill: #e6edf3; }
+      .note { fill: #8b949e; }
+      .edge { stroke: #8b949e; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#656d76"/></marker>
+    <marker id="arrow-simple" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#1a7f37"/></marker>
+    <marker id="arrow-complex" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#9a6700"/></marker>
+    <marker id="arrow-reflect" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#8250df"/></marker>
+  </defs>
+
+  <text x="450" y="30" class="title" text-anchor="middle">ragorchestrator — LangGraph Supervisor Flow</text>
+
+  <!-- Client -->
+  <rect x="370" y="50" width="160" height="36" class="box service"/>
+  <text x="450" y="68" class="label">Client :8095</text>
+
+  <!-- Classifier -->
+  <rect x="370" y="120" width="160" height="36" class="box node"/>
+  <text x="450" y="138" class="label">classify(query)</text>
+  <path d="M 450 86 L 450 120" class="edge"/>
+
+  <!-- SIMPLE path -->
+  <rect x="100" y="200" width="160" height="36" class="box simple"/>
+  <text x="180" y="218" class="label">ragpipe (direct)</text>
+  <path d="M 390 156 L 180 200" class="edge-simple"/>
+  <text x="240" y="180" class="note">SIMPLE</text>
+
+  <!-- Response (simple) -->
+  <rect x="100" y="270" width="160" height="36" class="box simple"/>
+  <text x="180" y="288" class="label">response + metadata</text>
+  <path d="M 180 236 L 180 270" class="edge-simple"/>
+
+  <!-- COMPLEX/EXTERNAL path -->
+  <!-- Supervisor -->
+  <rect x="520" y="200" width="160" height="36" class="box node"/>
+  <text x="600" y="218" class="label">supervisor (LLM)</text>
+  <path d="M 510 156 L 600 200" class="edge-complex"/>
+  <text x="560" y="180" class="note">COMPLEX / EXTERNAL</text>
+
+  <!-- Decompose -->
+  <rect x="520" y="280" width="160" height="36" class="box node"/>
+  <text x="600" y="298" class="label">decompose</text>
+  <path d="M 600 236 L 600 280" class="edge-complex"/>
+  <text x="690" y="262" class="note">tool_calls?</text>
+
+  <!-- Tools (single) -->
+  <rect x="720" y="350" width="140" height="36" class="box node"/>
+  <text x="790" y="368" class="label">tools (single)</text>
+  <path d="M 640 316 L 790 350" class="edge"/>
+  <text x="730" y="332" class="note">1 query</text>
+
+  <!-- Multi-tools (parallel) -->
+  <rect x="390" y="350" width="160" height="36" class="box node"/>
+  <text x="470" y="368" class="label">multi_tools (parallel)</text>
+  <path d="M 560 316 L 470 350" class="edge"/>
+  <text x="490" y="332" class="note">2-3 queries</text>
+
+  <!-- ragpipe calls -->
+  <rect x="100" y="350" width="140" height="36" class="box service"/>
+  <text x="170" y="368" class="label">ragpipe :8090</text>
+  <path d="M 390 368 L 240 368" class="edge"/>
+
+  <!-- Generate -->
+  <rect x="520" y="430" width="160" height="36" class="box node"/>
+  <text x="600" y="448" class="label">generate (LLM)</text>
+  <path d="M 470 386 L 600 430" class="edge"/>
+  <path d="M 790 386 L 600 430" class="edge"/>
+
+  <!-- Reflect -->
+  <rect x="520" y="510" width="160" height="36" class="box reflect"/>
+  <text x="600" y="528" class="label">reflect (Self-RAG)</text>
+  <path d="M 600 466 L 600 510" class="edge"/>
+
+  <!-- Reflection outcomes -->
+  <!-- GROUNDED + USEFUL → END -->
+  <rect x="520" y="600" width="160" height="36" class="box simple"/>
+  <text x="600" y="618" class="label">response</text>
+  <path d="M 600 546 L 600 600" class="edge"/>
+  <text x="540" y="575" class="note">grounded + useful</text>
+
+  <!-- UNGROUNDED → regenerate -->
+  <path d="M 520 528 Q 440 528 440 448 Q 440 440 520 440" class="edge-reflect"/>
+  <text x="420" y="488" class="note" text-anchor="end">ungrounded</text>
+
+  <!-- NOT_USEFUL → re-retrieve -->
+  <path d="M 680 528 Q 780 528 780 298 Q 780 290 680 290" class="edge-reflect"/>
+  <text x="800" y="420" class="note">not useful</text>
+
+  <!-- Legend -->
+  <rect x="30" y="620" width="12" height="12" fill="#1a7f37" rx="2"/>
+  <text x="48" y="631" class="note" style="font-style: normal">Simple path</text>
+  <rect x="130" y="620" width="12" height="12" fill="#9a6700" rx="2"/>
+  <text x="148" y="631" class="note" style="font-style: normal">Complex path</text>
+  <rect x="240" y="620" width="12" height="12" fill="#8250df" rx="2"/>
+  <text x="258" y="631" class="note" style="font-style: normal">Self-RAG retry</text>
+  <rect x="350" y="620" width="12" height="12" fill="#656d76" rx="2"/>
+  <text x="368" y="631" class="note" style="font-style: normal">Internal edge</text>
+
+  <text x="450" y="680" class="note" text-anchor="middle">max 2 retries per query — loop_count enforced in reflect node</text>
+</svg>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,98 @@
+# API Reference
+
+## POST /v1/chat/completions
+
+OpenAI-compatible chat completions endpoint. Drop-in replacement for ragpipe.
+
+### Request
+
+```bash
+curl http://localhost:8095/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is NATO article 5?"}],
+    "stream": false
+  }'
+```
+
+### Response
+
+```json
+{
+  "id": "chatcmpl-abc123def456",
+  "object": "chat.completion",
+  "model": "default",
+  "complexity": "simple",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "NATO Article 5 states that..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "rag_metadata": {
+    "grounding": "corpus",
+    "cited_chunks": [
+      {"id": "abc-123:0", "title": "NATO Treaty", "source": "gdrive://nato.pdf"}
+    ],
+    "corpus_coverage": "full",
+    "retrieval_attempts": 1,
+    "query_rewritten": false
+  }
+}
+```
+
+### Response fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique completion ID |
+| `object` | string | Always `chat.completion` |
+| `model` | string | Model name from request |
+| `complexity` | string | Query classification: `simple`, `complex`, or `external` |
+| `choices` | array | OpenAI-compatible choices array |
+| `rag_metadata` | object | RAG metadata from ragpipe (optional, present when ragpipe was called) |
+
+### rag_metadata fields
+
+Passed through from ragpipe when the supervisor calls the ragpipe_retrieval tool:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `grounding` | string | `corpus`, `general`, or `mixed` |
+| `cited_chunks` | array | List of `{id, title, source}` objects |
+| `corpus_coverage` | string | `full` or `none` |
+| `retrieval_attempts` | int | 1 = normal, 2 = CRAG retry |
+| `query_rewritten` | bool | Whether CRAG triggered a query rewrite |
+
+### Error responses
+
+Errors return HTTP 500 with an OpenAI-compatible body that includes both `choices` and `error`:
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "model": "default",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "I encountered an error..."}, "finish_reason": "stop"}],
+  "error": "Connection error."
+}
+```
+
+### Streaming
+
+Streaming responses (`"stream": true`) return SSE events. The `complexity` field is emitted as a separate SSE event before `[DONE]`.
+
+## GET /health
+
+```json
+{"status": "ok", "version": "0.1.0"}
+```
+
+## GET /metrics
+
+Prometheus text format. See [architecture.md](architecture.md#metrics) for metric descriptions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,126 @@
+# Architecture
+
+ragorchestrator is a LangGraph-based supervisor agent that sits above [ragpipe](https://github.com/aclater/ragpipe), adding adaptive complexity routing, multi-pass retrieval, and Self-RAG reflection to the RAG pipeline.
+
+## System context
+
+```
+Client → ragorchestrator (:8095) → LangGraph supervisor
+                                        ↓
+                                  ragpipe (:8090) ← corpus retrieval
+                                        ↓
+                                  LLM (:8080) ← generation + reflection
+```
+
+ragorchestrator exposes the same OpenAI-compatible `/v1/chat/completions` API as ragpipe. Clients can switch between the two by changing the port — no other changes needed.
+
+## LangGraph state machine
+
+The supervisor graph has 6 nodes connected by conditional edges:
+
+```
+                    ┌─────────────┐
+                    │  supervisor  │  ← entry point
+                    └──────┬──────┘
+                           │
+                    should_retrieve?
+                    ╱              ╲
+              tool_calls        no tools
+                 ╱                    ╲
+        ┌──────────┐          ┌──────────┐
+        │ decompose │          │ generate  │
+        └─────┬────┘          └─────┬────┘
+              │                     │
+       should_use_multipass?        │
+        ╱              ╲            │
+   ┌──────────┐  ┌─────────┐       │
+   │multi_tools│  │  tools   │      │
+   └─────┬────┘  └────┬────┘       │
+         │            │             │
+         └──────┬─────┘             │
+                ↓                   │
+         ┌──────────┐               │
+         │ generate  │ ←────────────┘
+         └─────┬────┘
+               │
+         ┌──────────┐
+         │  reflect  │  ← Self-RAG grading
+         └─────┬────┘
+               │
+        should_regenerate?
+        ╱       │        ╲
+   generate  decompose    END
+   (retry)   (re-retrieve)
+```
+
+### Nodes
+
+| Node | Purpose |
+|------|---------|
+| `supervisor` | LLM with bound tools decides whether to call ragpipe or respond directly |
+| `decompose` | Splits complex queries into 2-3 sub-queries via LLM |
+| `tools` | Single ragpipe call via LangGraph ToolNode |
+| `multi_tools` | Parallel ragpipe calls for each sub-query (asyncio.gather) |
+| `generate` | LLM generates answer from retrieved documents |
+| `reflect` | Self-RAG grading: hallucination + usefulness checks |
+
+### Conditional edges
+
+| Edge | Condition | Routes to |
+|------|-----------|-----------|
+| `should_retrieve` | supervisor made tool_calls → decompose; otherwise → generate |
+| `should_use_multipass` | >1 sub-query → multi_tools; otherwise → tools |
+| `should_regenerate` | UNGROUNDED → generate (retry); NOT_USEFUL → decompose (re-retrieve); else → END |
+
+### State schema
+
+```python
+class AgentState(TypedDict):
+    messages: Annotated[list, add_messages]  # LangChain message history
+    question: str                            # extracted user question
+    generation: str                          # current generation text
+    documents: list                          # retrieved document chunks
+    loop_count: int                          # retry counter (max 2)
+```
+
+## Request flow
+
+### Simple queries (SIMPLE complexity)
+
+```
+POST /v1/chat/completions
+  → classify("who is Adam?") → SIMPLE
+  → _simple_path(): direct HTTP call to ragpipe
+  → return ragpipe response with rag_metadata
+```
+
+Latency: ~2-5s (single ragpipe call)
+
+### Complex queries (COMPLEX/EXTERNAL complexity)
+
+```
+POST /v1/chat/completions
+  → classify("compare NATO article 5 with patent claims") → COMPLEX
+  → _agentic_path(): LangGraph ainvoke()
+    → supervisor: LLM decides to call ragpipe_retrieval
+    → decompose: split into sub-queries
+    → multi_tools: parallel ragpipe calls
+    → generate: synthesize answer from documents
+    → reflect: grade hallucination + usefulness
+    → (retry if needed, max 2 iterations)
+  → extract rag_metadata from tool results
+  → return OpenAI-compatible response
+```
+
+Latency: ~30-120s (5+ sequential LLM calls with Qwen3-32B)
+
+## Metrics
+
+Prometheus metrics exposed at `/metrics`:
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ragorchestrator_queries_total` | Counter | status | Total queries processed |
+| `ragorchestrator_query_latency_seconds` | Histogram | | Query latency |
+| `ragorchestrator_tool_calls_total` | Counter | tool | Tool calls by supervisor |
+| `ragorchestrator_complexity_classified_total` | Counter | complexity | Queries by complexity class |

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -1,0 +1,45 @@
+# Adaptive Complexity Classifier
+
+Deterministic keyword-based query classifier that routes queries to the appropriate processing path.
+
+## Complexity levels
+
+| Level | Path | Description |
+|-------|------|-------------|
+| `SIMPLE` | Direct ragpipe call | Factual lookups, single-topic questions |
+| `COMPLEX` | Full LangGraph loop | Multi-topic analysis, comparisons, reasoning |
+| `EXTERNAL` | LangGraph + web search | Current events, stock prices, weather |
+
+## Classification priority
+
+The classifier evaluates patterns in order — first match wins:
+
+1. **EXTERNAL indicators**: `news`, `weather`, `stock price`, `celebrity`, `competitor`
+2. **COMPLEX indicators**: `compare`, `analyze`, `pros/cons`, `impact`, `relationship`
+3. **Length threshold**: queries >200 characters → COMPLEX
+4. **SIMPLE indicators**: question starters (`who`, `what`, `when`), commands (`list`, `find`, `get`)
+5. **Short questions**: <=5 words with `?` → SIMPLE
+6. **Non-alpha**: no alphabetic characters → SIMPLE
+7. **Default**: COMPLEX
+
+## Examples
+
+```
+"Who is Adam Clater?"                              → SIMPLE
+"What is NATO article 5?"                          → SIMPLE
+"List all employees"                               → SIMPLE
+"Compare NATO article 5 with patent claims"        → COMPLEX
+"Analyze the pros and cons of this approach"        → COMPLEX
+"What is the latest news?"                         → EXTERNAL
+"hello"                                            → COMPLEX (default)
+```
+
+## Tuning
+
+The classifier uses regex patterns defined in `classifier.py`. To adjust:
+
+- Add patterns to `SIMPLE_INDICATORS` to route more queries to the fast path
+- Add patterns to `COMPLEX_INDICATORS` to trigger the agentic loop
+- Adjust `LLM_THRESHOLD_QUERY_LENGTH` (default 200) for the length heuristic
+
+The `complexity` field in the API response shows which path was taken, useful for debugging classification behavior.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,47 @@
+# Configuration
+
+All configuration is via environment variables. No config files.
+
+## Required
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL_URL` | `http://127.0.0.1:8080` | LLM endpoint (OpenAI-compatible). Must use IPv4 — llama-vulkan only listens on IPv4. |
+| `RAGPIPE_URL` | `http://localhost:8090` | ragpipe endpoint for corpus retrieval |
+
+## Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL_NAME` | `model.file` | Model identifier passed to ChatOpenAI |
+| `RAGPIPE_ADMIN_TOKEN` | (empty) | Bearer token for ragpipe authentication |
+| `RAGORCHESTRATOR_PORT` | `8095` | Listen port for the FastAPI server |
+| `TAVILY_API_KEY` | (unset) | Tavily API key for web search. Tool disabled when unset. |
+| `DISABLE_WEB_SEARCH` | (unset) | Set to `true`, `yes`, or `1` to force-disable web search even when API key is present |
+| `LANGSMITH_TRACING` | (unset) | Set to `true` to enable LangSmith tracing. Disabled by default for sovereign deployment. |
+
+## Deployment notes
+
+### IPv4 requirement
+
+`MODEL_URL` must use `127.0.0.1` (not `localhost`) when targeting llama-vulkan on Fedora. Python resolves `localhost` to `::1` (IPv6) first, but llama-vulkan only listens on IPv4. This applies to all services running as rootless Podman containers with `Network=host`.
+
+### Sovereign mode
+
+Set `DISABLE_WEB_SEARCH=true` to ensure no external API calls are made. In this mode:
+- Only the ragpipe_retrieval tool is available
+- EXTERNAL queries fall back to ragpipe-only retrieval
+- No data leaves the local network
+
+### Container deployment
+
+The Podman quadlet sets all required variables:
+
+```ini
+Environment=MODEL_URL=http://127.0.0.1:8080
+Environment=RAGPIPE_URL=http://host.containers.internal:8090
+Environment=DISABLE_WEB_SEARCH=true
+EnvironmentFile=%h/.config/llm-stack/ragstack.env
+```
+
+Secrets (`RAGPIPE_ADMIN_TOKEN`, `TAVILY_API_KEY`) are sourced from `ragstack.env` — never committed to git.

--- a/docs/multipass.md
+++ b/docs/multipass.md
@@ -1,0 +1,47 @@
+# Multi-Pass Retrieval
+
+Complex queries are decomposed into simpler sub-queries, each retrieved in parallel from ragpipe, then merged and deduplicated before generation.
+
+## Flow
+
+```
+decompose_query("compare personnel roles with NATO obligations")
+  → ["What are the personnel roles?", "What are the NATO obligations?"]
+
+multi_tools_node:
+  → asyncio.gather(
+      ragpipe("What are the personnel roles?"),
+      ragpipe("What are the NATO obligations?"),
+    )
+  → merge cited_chunks from all responses
+  → deduplicate by (doc_id, chunk_id), preserving first occurrence
+
+generate:
+  → synthesize answer from merged document set
+```
+
+## Decomposition
+
+The LLM decomposes complex queries into 2-3 sub-questions using a structured JSON prompt. The response must be a JSON array of strings:
+
+```json
+["What are the personnel roles?", "What are the NATO obligations?"]
+```
+
+`MAX_SUB_QUERIES = 3` — additional sub-queries are truncated.
+
+If decomposition fails (LLM returns invalid JSON, timeout), the original query is used as the sole sub-query — single-pass retrieval as fallback.
+
+## Parallel retrieval
+
+Sub-queries are sent to ragpipe concurrently via `asyncio.gather`. Each call hits ragpipe's full pipeline (semantic routing, Qdrant search, docstore hydration, reranking). Individual failures return empty results without blocking other sub-queries.
+
+## Deduplication
+
+Documents from all sub-queries are merged and deduplicated by `(doc_id, chunk_id)`. First occurrence is kept, preserving the ordering from the most relevant sub-query.
+
+## When multi-pass activates
+
+The `should_use_multipass` edge checks the number of sub-queries:
+- 1 sub-query → single `tools` node (standard ToolNode execution)
+- 2+ sub-queries → `multi_tools` node (parallel retrieval)

--- a/docs/self-rag.md
+++ b/docs/self-rag.md
@@ -1,0 +1,55 @@
+# Self-RAG Reflection
+
+After generating an answer, the supervisor grades its own response for groundedness and usefulness. If the response fails either check, it retries — up to 2 times.
+
+## Grading pipeline
+
+```
+generate → reflect
+              │
+        grade_hallucination(question, documents, generation)
+              │
+         GROUNDED?
+         ╱        ╲
+       yes         no → regenerate (stricter prompt)
+        │
+   grade_answer(question, generation)
+        │
+      USEFUL?
+      ╱      ╲
+    yes       no → re-retrieve (rewritten query)
+     │
+    END
+```
+
+## Grades
+
+| Grade | Meaning | Action |
+|-------|---------|--------|
+| `GROUNDED` | Response supported by retrieved documents | Continue to answer grading |
+| `UNGROUNDED` | Response contains claims not in documents | Regenerate with stricter prompt |
+| `USEFUL` | Response addresses the original question | Return to client |
+| `NOT_USEFUL` | Response is off-topic or incomplete | Re-retrieve with new sub-queries |
+
+## Grading prompts
+
+Both graders use the LLM with temperature=0 and structured JSON output:
+
+- **Hallucination grader**: "Is the response factually supported by the documents? Return `{\"grade\": \"yes\"}` or `{\"grade\": \"no\"}`"
+- **Answer grader**: "Does the response meaningfully address the question? Return `{\"grade\": \"yes\"}` or `{\"grade\": \"no\"}`"
+
+## Short-circuit on grounding=general
+
+When ragpipe classifies the query as `grounding=general` (no corpus match), the hallucination grader is skipped entirely — there are no documents to grade against. The reflect node triggers re-retrieval directly, saving one LLM call.
+
+## Retry limits
+
+`MAX_RETRIES = 2` — the reflect node increments `loop_count` on each iteration. After 2 retries, the current generation is returned regardless of grade. This prevents infinite loops on genuinely unanswerable queries.
+
+## Error handling
+
+If either grader call fails (LLM timeout, malformed response), the grade defaults to the optimistic case:
+- Hallucination grader failure → `GROUNDED`
+- Answer grader failure → `USEFUL`
+
+This ensures errors don't cause unnecessary retries or block response delivery.


### PR DESCRIPTION
Closes #37
Closes #38

## Summary
- Created `docs/` with 6 files: architecture, classifier, self-rag, multipass, api, configuration
- Added `architecture.svg` showing LangGraph flow with color-coded complexity paths and Self-RAG retry loop
- Expanded README from 67 to ~95 lines with feature highlights and linked table of contents

## Test plan
- [ ] SVG renders correctly on GitHub (light and dark mode)
- [ ] All docs/ links resolve from README
- [ ] No broken cross-links between docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API reference and system architecture documentation
  * Documented query complexity routing, multi-pass retrieval with parallelism and deduplication, and Self-RAG reflection workflow (up to 2 retries)
  * Added configuration guide for environment variables
  * Updated README with visual architecture diagram, expanded features, and health/metrics examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->